### PR TITLE
Added Slack slash command integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ Houston::Slack.config do
 end
 ```
 
+### Slash Commands
+
+`Houston::Slack::Slash` can respond to [slash commands](https://api.slack.com/slash-commands) created for your team in Slack. A slash command sends Houston user inputed text and **must** receive a message in response. 
+
+When you create a slash command on Slack set the **URL** to `http://houstondomain.com/slack/command` and set the method to `POST`.
+
+###### Example
+
+This example responds to the slash command `/weather` where the user is expected to enter a zipcode.
+
+```ruby
+Houston::Slack.config do
+  slash("weather") do |e|
+    zipcode = e.text
+    weather = WeatherAPI.get_weather(zipcode)
+    message = "Today is #{weather.to_s}"
+    e.respond! message
+  end
+end
+```
 
 
 ## Contributing

--- a/app/controllers/houston/slack/slack_controller.rb
+++ b/app/controllers/houston/slack/slack_controller.rb
@@ -1,5 +1,8 @@
+require "houston/slack/slash_command"
+
 module Houston::Slack
   class SlackController < ApplicationController
+    skip_before_filter :verify_authenticity_token, only: [:command]
 
     def show
       @connection = Houston::Slack.connection
@@ -8,6 +11,18 @@ module Houston::Slack
     def connect
       Houston::Slack.connection.listen! unless Houston::Slack.connection.listening?
       redirect_to action: :show
+    end
+
+    def command
+      command = Houston::Slack.config.slash_commands[params[:command].gsub(/^\//, "")]
+      unless command
+        render text: "A slash command named '#{params[:command]}' is not defined", status: 404
+        return
+      end
+
+      e = Houston::Slack::SlashCommand.new(self, params)
+      command.call e
+      head :no_content unless performed?
     end
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Houston::Slack::Engine.routes.draw do
   scope "slack" do
     get "/", to: "slack#show"
     post "/connect", to: "slack#connect"
+    post "/command", to: "slack#command"
   end
 
 end

--- a/lib/houston/slack/configuration.rb
+++ b/lib/houston/slack/configuration.rb
@@ -3,11 +3,12 @@ require "thread_safe"
 
 module Houston::Slack
   class Configuration
-    attr_reader :listeners
+    attr_reader :listeners, :slash_commands
 
     def initialize
       @listeners = ThreadSafe::Array.new
       @typing_speed = 100.0
+      @slash_commands = {}
     end
 
     # Define configuration DSL here
@@ -32,6 +33,10 @@ module Houston::Slack
       Listener.new(matcher, false, block).tap do |listener|
         @listeners.push listener
       end
+    end
+
+    def slash(command_name, &block)
+      @slash_commands[command_name] = block
     end
 
   end

--- a/lib/houston/slack/errors.rb
+++ b/lib/houston/slack/errors.rb
@@ -12,5 +12,11 @@ module Houston
         additional_information[:response] = response
       end
     end
+
+    class AlreadyRespondedError < RuntimeError
+      def initialize(message=nil)
+        super message || "You have already replied to this Slash Command; you can only reply once"
+      end
+    end
   end
 end

--- a/lib/houston/slack/slash_command.rb
+++ b/lib/houston/slack/slash_command.rb
@@ -1,0 +1,19 @@
+module Houston::Slack
+  class SlashCommand
+    attr_reader :text
+
+    def initialize(controller, params)
+      @controller = controller
+      @text = params.fetch :text
+    end
+
+    def respond!(message)
+      raise Houston::Slack::AlreadyRespondedError if controller.performed?
+      controller.render text: message
+    end
+
+  private
+    attr_reader :controller
+
+  end
+end


### PR DESCRIPTION
_From the README_
### Slash Commands

`Houston::Slack::Slash` can respond to [slash commands](https://api.slack.com/slash-commands) created for your team in Slack. A slash command sends Houston user inputed text and **must** receive a message in response. 

When you create a slash command on Slack set the **URL** to `http://houstondomain.com/slack/command` and set the method to `POST`.
###### Example

This example responds to the slash command `/weather` where the user is expected to enter a zipcode.

``` ruby
Houston::Slack.config do
  slash("weather") do |e|
    zipcode = e.text
    weather = WeatherAPI.get_weather(zipcode)
    message = "Today is #{weather.to_s}"
    e.respond! message
  end
end
```
