### PR TITLE
Delayed Respond

### DIFF
--- a/app/controllers/houston/slack/slack_controller.rb
+++ b/app/controllers/houston/slack/slack_controller.rb
@@ -36,9 +36,17 @@ module Houston::Slack
       end
 
       text = params.fetch :text
-      channel = Houston::Slack::Channel.find(params.fetch(:channel_id))
       response_url = params.fetch :response_url
       sender = Houston::Slack::User.find(params.fetch(:user_id))
+
+      begin
+        channel = Houston::Slack::Channel.find(params.fetch(:channel_id))
+      rescue ArgumentError
+        # Happens when using a slash command in a DM or channel that Houston is
+        # not privy to. But as long as we're using only `respond!` or
+        # `delayed_respond!`, we don't really need the channel.
+        channel = Houston::Slack::GuestChannel.new(params)
+      end
 
       e = Houston::Slack::SlashCommand.new(
         message: text,

--- a/app/controllers/houston/slack/slack_controller.rb
+++ b/app/controllers/houston/slack/slack_controller.rb
@@ -37,12 +37,14 @@ module Houston::Slack
 
       text = params.fetch :text
       channel = Houston::Slack::Channel.find(params.fetch(:channel_id))
+      response_url = params.fetch :response_url
       sender = Houston::Slack::User.find(params.fetch(:user_id))
 
       e = Houston::Slack::SlashCommand.new(
         message: text,
         channel: channel,
         sender: sender,
+        response_url: response_url,
         controller: self)
 
       command.call e

--- a/lib/houston/slack/channel.rb
+++ b/lib/houston/slack/channel.rb
@@ -68,6 +68,10 @@ module Houston
       alias :group? :private_group?
       alias :private? :private_group?
 
+      def guest?
+        false
+      end
+
       def inspect
         "<Houston::Slack::Channel id=\"#{id}\" name=\"#{name}\">"
       end

--- a/lib/houston/slack/conversation.rb
+++ b/lib/houston/slack/conversation.rb
@@ -4,6 +4,8 @@ module Houston::Slack
   class Conversation
 
     def initialize(channel, sender)
+      raise NotInChannelError, channel if channel.guest?
+
       @channel = channel
       @sender = sender
       @listeners = ThreadSafe::Array.new

--- a/lib/houston/slack/errors.rb
+++ b/lib/houston/slack/errors.rb
@@ -18,5 +18,11 @@ module Houston
         super message || "You have already replied to this Slash Command; you can only reply once"
       end
     end
+
+    class NotInChannelError < RuntimeError
+      def initialize(channel)
+        super "Houston is not in the channel #{channel} and cannot reply"
+      end
+    end
   end
 end

--- a/lib/houston/slack/guest_channel.rb
+++ b/lib/houston/slack/guest_channel.rb
@@ -1,0 +1,36 @@
+# This is a channel that Houston is aware of
+# but is not a member of — and cannot reply to.
+#
+# It should expose the same API as channel,
+# but you will not be able to reply on this
+# channel or start a conversation on it.
+
+module Houston
+  module Slack
+    class GuestChannel < Channel
+
+      def initialize(params)
+        @id = attributes["channel_id"]
+        @name = attributes["channel_name"]
+
+        @type = :channel
+        @type = :group if id.start_with?("G")
+        @type = :direct_message if id.start_with?("D")
+      end
+
+      def reply(*args)
+        raise NotInChannelError, self
+      end
+      alias :say :reply
+
+      def random_reply(*args)
+        raise NotInChannelError, self
+      end
+
+      def guest?
+        true
+      end
+
+    end
+  end
+end

--- a/lib/houston/slack/slash_command.rb
+++ b/lib/houston/slack/slash_command.rb
@@ -3,9 +3,10 @@ require "houston/slack/event"
 module Houston::Slack
   class SlashCommand < Event
 
-    def initialize(message: nil, channel: nil, sender: nil, controller: nil)
+    def initialize(message: nil, channel: nil, sender: nil, controller: nil, response_url: nil)
       super(message: message, channel: channel, sender: sender)
       @controller = controller
+      @response_url = response_url
     end
 
     def respond!(message)
@@ -14,13 +15,18 @@ module Houston::Slack
       controller.render json: message
     end
 
+    def delayed_respond!(message)
+      message = {text: message} if message.is_a?(String)
+      Faraday.post response_url, message, { "Content-Type" => "application/json" }
+    end
+
     def text
       puts "DEPRECATED: use `Houston::Slack::SlashCommand#message` instead of `text`"
       message
     end
 
   private
-    attr_reader :controller
+    attr_reader :controller, :response_url
 
   end
 end


### PR DESCRIPTION
Enables a delayed response (taking more than 3000ms) when responding to a slash command, utilizing the given `response_url`.

Also gracefully handle a slash command executed in a channel that Houston doesn't have access to.
